### PR TITLE
Update shadowsocks-libev.init

### DIFF
--- a/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/shadowsocks-libev/files/shadowsocks-libev.init
@@ -371,7 +371,7 @@ validate_common_server_options_() {
 	local cfgtype="$1"; shift
 	local cfg="$1"; shift
 	local func="$1"; shift
-	local stream_methods='"table", "rc4", "rc4-md5", "aes-128-cfb", "aes-192-cfb", "aes-256-cfb", "aes-128-ctr", "aes-192-ctr", "aes-256-ctr", "bf-cfb", "camellia-128-cfb", "camellia-192-cfb", "camellia-256-cfb", "salsa20", "chacha20", "chacha20-ietf"'
+	local stream_methods='"none", "table", "rc4", "rc4-md5", "aes-128-cfb", "aes-192-cfb", "aes-256-cfb", "aes-128-ctr", "aes-192-ctr", "aes-256-ctr", "bf-cfb", "camellia-128-cfb", "camellia-192-cfb", "camellia-256-cfb", "salsa20", "chacha20", "chacha20-ietf"'
 	local aead_methods='"aes-128-gcm", "aes-192-gcm", "aes-256-gcm", "chacha20-ietf-poly1305", "xchacha20-ietf-poly1305"'
 
 	"${func:-ss_validate}" "$cfgtype" "$cfg" "$@" \


### PR DESCRIPTION
"none" option is available inside the webui & in parameters of shadowsocks commands but not int the init file