### PR TITLE
Don't force an ERROR in shared interfaces

### DIFF
--- a/luci-app-openmptcprouter/luasrc/controller/openmptcprouter.lua
+++ b/luci-app-openmptcprouter/luasrc/controller/openmptcprouter.lua
@@ -895,7 +895,7 @@ function interfaces_status()
 	    duplicateif = false
 	    if ifname ~= "" and ifname ~= nil then
 		if allintf[ifname] then
-		    connectivity = "ERROR"
+		    --connectivity = "ERROR"
 		    duplicateif = true
 		else
 		    allintf[ifname] = true

--- a/luci-app-openmptcprouter/luasrc/view/openmptcprouter/wanstatus.htm
+++ b/luci-app-openmptcprouter/luasrc/view/openmptcprouter/wanstatus.htm
@@ -405,7 +405,7 @@
 					if(duplicateif)
 					{
 						statusMessage += 'Network interface duplicated<br />';
-						statusMessageClass = "error";
+						statusMessageClass = "warning";
 					}
 					if(ipv6_discover == 'DETECTED')
 					{


### PR DESCRIPTION
When one Interface shares the Physical Device, this _can be_ a problem. However, not in all cases (for exemple, when using PPPoE connections). So, mark them as "warning", and not "error".
