### PR TITLE
clear OMR_TRACKER_DEVICE_GATEWAY

### DIFF
--- a/omr-tracker/files/bin/omr-tracker
+++ b/omr-tracker/files/bin/omr-tracker
@@ -159,6 +159,7 @@ while true; do
 	OMR_TRACKER_LATENCY=
 	OMR_TRACKER_TIMEOUT=$((rto / 1000 + (rto % 1000 ? 1 : 0)))
 	OMR_TRACKER_LIST_HOSTS=""
+	OMR_TRACKER_DEVICE_GATEWAY=
 	serverip_ping=false
 
 	if [ -d "/sys/class/net/$OMR_TRACKER_DEVICE" ]; then


### PR DESCRIPTION
OMR_TRACKER_DEVICE_GATEWAY variable may change over time and must be cleared in new cycle
