### PR TITLE
always type is "ping" for an "interface"

### DIFF
--- a/omr-tracker/files/etc/init.d/omr-tracker
+++ b/omr-tracker/files/etc/init.d/omr-tracker
@@ -21,7 +21,7 @@ _validate_section() {
 		'tries:uinteger'    \
 		'interval:uinteger' \
 		'interval_tries:uinteger' \
-		'type:string:ping'  \
+		'type:string:undef'  \
 		'enabled:bool:1'    \
 		'options:string'
 
@@ -31,7 +31,7 @@ _validate_section() {
 	[ -z "$interval" ] && interval=$tmp_interval
 	[ -z "$interval_tries" ] && interval_tries=$tmp_interval_tries
 	[ -z "$options"  ] && options=$tmp_options
-	[ -z "$type"  ] && type=$tmp_type
+	[ "$type" = "undef"  ] && type=${tmp_type:-ping}
 	[ -z "$enabled"  ] && enabled=$tmp_enabled
 }
 


### PR DESCRIPTION
Tracker type for an "interface" does not inherit global configuration and always be set "ping", or needs be set explicitly
