### PR TITLE
Potential performance improvement for omr-bypass with ndpi global gTLD rules

### DIFF
--- a/contributors/cr3ative.md
+++ b/contributors/cr3ative.md
@@ -1,0 +1,9 @@
+2020-11-10
+
+I hereby agree to the terms of the "OpenMPTCProuter Individual Contributor License Agreement", with MD5 checksum bc827a07eb93611d793ddb7c75083c00.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Paul Curry https://github.com/cr3ative

--- a/luci-app-omr-bypass/root/etc/init.d/omr-bypass
+++ b/luci-app-omr-bypass/root/etc/init.d/omr-bypass
@@ -349,7 +349,7 @@ _bypass_proto() {
 					done
 					domainlist="$(echo $domainlist  `# Get the list of valid domains, pass it to awk` \
 						| awk '{print tolower($0)}'   `# awk lowercases the whole string and passes it to ` \
-						| xargs -n8 -P12              `# xargs sends 8 arguments at a time across 12 threads to` \
+						| xargs -n8                   `# xargs sends 8 arguments at a time to` \
 							dig a +nocmd +noall +answer `# dig, which passes results (if any) to` \
 						| awk '{print $1}'            `# awk, which outputs queried domain to` \
 						| sed -e 's/.$//'             `# sed, which trims off the trailing dot (google.com. -> google.com)` \

--- a/luci-app-omr-bypass/root/etc/init.d/omr-bypass
+++ b/luci-app-omr-bypass/root/etc/init.d/omr-bypass
@@ -331,32 +331,32 @@ _bypass_proto() {
 	local domains
 	domains="$(cat /proc/net/xt_ndpi/host_proto | grep -i $proto: | sed -e "s/$proto://i" -e 's/*//' -e 's/,/ /g')"
 	if [ -n "$domains" ]; then
-    tlds=`curl --max-time 4 -s -k https://data.iana.org/TLD/tlds-alpha-by-domain.txt`
+		tlds=`curl --max-time 4 -s -k https://data.iana.org/TLD/tlds-alpha-by-domain.txt`
 		for domain in $domains; do
 			if [ -n "$domain" ]; then
 				domain="$(echo $domain | sed 's/^\.//')"
 				if [ "$(echo $domain | grep '\.$')" != "" ]; then
 					domainlist=""
-          # construct list of domains to query
-          for tld in $tlds; do
-            i=$((i+1))
-            # trim off header
-            if [ "$i" -lt "12" ] || [ "$i" -gt "50" ]; then
-              continue
-            fi 
-            # add to command
-            domainlist="${domainlist} ${domain}${tld}"
-          done
-            domainlist="$(echo $domainlist  `# Get the list of valid domains, pass it to awk` \
-              | awk '{print tolower($0)}'   `# awk lowercases the whole string and passes it to ` \
-              | xargs -n8 -P12              `# xargs sends 8 arguments at a time across 12 threads to` \
-                dig a +nocmd +noall +answer `# dig, which passes results (if any) to` \
-              | awk '{print $1}'            `# awk, which outputs queried domain to` \
-              | sed -e 's/.$//'             `# sed, which trims off the trailing dot (google.com. -> google.com)` \
-              | awk '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}{printf("\n")}')" # deduplicate
-          for validdomain in $domainlist; do
-            _bypass_domain $validdomain $intf
-          done
+					# construct list of domains to query
+					for tld in $tlds; do
+					i=$((i+1))
+					# trim off header
+					if [ "$i" -lt "12" ] || [ "$i" -gt "50" ]; then
+					continue
+					fi 
+					# add to command
+					domainlist="${domainlist} ${domain}${tld}"
+					done
+					domainlist="$(echo $domainlist  `# Get the list of valid domains, pass it to awk` \
+					| awk '{print tolower($0)}'   `# awk lowercases the whole string and passes it to ` \
+					| xargs -n8 -P12              `# xargs sends 8 arguments at a time across 12 threads to` \
+						dig a +nocmd +noall +answer `# dig, which passes results (if any) to` \
+					| awk '{print $1}'            `# awk, which outputs queried domain to` \
+					| sed -e 's/.$//'             `# sed, which trims off the trailing dot (google.com. -> google.com)` \
+					| awk '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}{printf("\n")}')" # deduplicate
+					for validdomain in $domainlist; do
+						_bypass_domain $validdomain $intf
+					done
 				else
 					_bypass_domain $domain $intf
 				fi

--- a/luci-app-omr-bypass/root/etc/init.d/omr-bypass
+++ b/luci-app-omr-bypass/root/etc/init.d/omr-bypass
@@ -339,21 +339,21 @@ _bypass_proto() {
 					domainlist=""
 					# construct list of domains to query
 					for tld in $tlds; do
-					i=$((i+1))
-					# trim off header
-					if [ "$i" -lt "12" ] || [ "$i" -gt "50" ]; then
-					continue
-					fi 
-					# add to command
-					domainlist="${domainlist} ${domain}${tld}"
+						i=$((i+1))
+						# trim off header
+						if [ "$i" -lt "12" ] || [ "$i" -gt "50" ]; then
+							continue
+						fi 
+						# add to command
+						domainlist="${domainlist} ${domain}${tld}"
 					done
 					domainlist="$(echo $domainlist  `# Get the list of valid domains, pass it to awk` \
-					| awk '{print tolower($0)}'   `# awk lowercases the whole string and passes it to ` \
-					| xargs -n8 -P12              `# xargs sends 8 arguments at a time across 12 threads to` \
-						dig a +nocmd +noall +answer `# dig, which passes results (if any) to` \
-					| awk '{print $1}'            `# awk, which outputs queried domain to` \
-					| sed -e 's/.$//'             `# sed, which trims off the trailing dot (google.com. -> google.com)` \
-					| awk '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}{printf("\n")}')" # deduplicate
+						| awk '{print tolower($0)}'   `# awk lowercases the whole string and passes it to ` \
+						| xargs -n8 -P12              `# xargs sends 8 arguments at a time across 12 threads to` \
+							dig a +nocmd +noall +answer `# dig, which passes results (if any) to` \
+						| awk '{print $1}'            `# awk, which outputs queried domain to` \
+						| sed -e 's/.$//'             `# sed, which trims off the trailing dot (google.com. -> google.com)` \
+						| awk '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}{printf("\n")}')" # deduplicate
 					for validdomain in $domainlist; do
 						_bypass_domain $validdomain $intf
 					done

--- a/luci-app-omr-bypass/root/etc/init.d/omr-bypass
+++ b/luci-app-omr-bypass/root/etc/init.d/omr-bypass
@@ -331,21 +331,32 @@ _bypass_proto() {
 	local domains
 	domains="$(cat /proc/net/xt_ndpi/host_proto | grep -i $proto: | sed -e "s/$proto://i" -e 's/*//' -e 's/,/ /g')"
 	if [ -n "$domains" ]; then
+    tlds=`curl --max-time 4 -s -k https://data.iana.org/TLD/tlds-alpha-by-domain.txt`
 		for domain in $domains; do
 			if [ -n "$domain" ]; then
 				domain="$(echo $domain | sed 's/^\.//')"
 				if [ "$(echo $domain | grep '\.$')" != "" ]; then
-					tlds=`curl --max-time 4 -s -k https://data.iana.org/TLD/tlds-alpha-by-domain.txt`
-					if [ -n "tlds" ]; then
-						i=0
-						for tld in $tlds; do
-							i=$((i+1))
-							tld="$(echo $tld | awk '{print tolower($0)}')"
-							if [ "$i" -gt "11" ] && [ "$(dig a +timeout=1 +tries=1 +retry=1 +nocmd +noall +answer ${domain}${tld})" != "" ]; then
-								_bypass_domain ${domain}${tld} $intf
-							fi
-						done
-					fi
+					domainlist=""
+          # construct list of domains to query
+          for tld in $tlds; do
+            i=$((i+1))
+            # trim off header
+            if [ "$i" -lt "12" ] || [ "$i" -gt "50" ]; then
+              continue
+            fi 
+            # add to command
+            domainlist="${domainlist} ${domain}${tld}"
+          done
+            domainlist="$(echo $domainlist  `# Get the list of valid domains, pass it to awk` \
+              | awk '{print tolower($0)}'   `# awk lowercases the whole string and passes it to ` \
+              | xargs -n8 -P12              `# xargs sends 8 arguments at a time across 12 threads to` \
+                dig a +nocmd +noall +answer `# dig, which passes results (if any) to` \
+              | awk '{print $1}'            `# awk, which outputs queried domain to` \
+              | sed -e 's/.$//'             `# sed, which trims off the trailing dot (google.com. -> google.com)` \
+              | awk '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}{printf("\n")}')" # deduplicate
+          for validdomain in $domainlist; do
+            _bypass_domain $validdomain $intf
+          done
 				else
 					_bypass_domain $domain $intf
 				fi


### PR DESCRIPTION
I noticed that the new omr-bypass while applying protocols with all IANA gTLDs on domains takes a very long time (possibly never completes on mine).

I took a little look at the script and realised that awk and dig could be parallelised with good effect in omr-bypass.

My idea appears to speed things up significantly. With warm caches on my local machine, it goes from 2.5 minutes to 11 seconds:

```
./old.sh   4.81s user 11.31s system 11% cpu 2:25.90 total
./new.sh  0.95s user 1.18s system 19% cpu 11.147 total
```

I've also removed the short timeout from `dig` with this parallelisation since the query can take longer. It doesn't seem to affect anything too badly.

**I'm not confident enough for you to merge this without changes** (for example, if dig fails to contact a server, the errors are passed through) but I thought it might be nice for you to see a suggestion :)

An isolated version to run locally to play with, which includes threading, but I'm unsure about it:

```
#!/bin/sh

tlds=`curl --max-time 4 -s -k https://data.iana.org/TLD/tlds-alpha-by-domain.txt`
domain="cloudflare."

if [ -n "tlds" ]; then
  i=0
  domainlist=""
  # construct list of domains to query
  for tld in $tlds; do
    i=$((i+1))
    # trim off header
    if [ "$i" -lt "12" ]; then
      continue
    fi 
    # add to command
    domainlist="${domainlist} ${domain}${tld}"
  done
  domainlist="$(echo $domainlist            `# Get the list of valid domains, pass it to awk` \
              | awk '{print tolower($0)}'   `# awk lowercases the whole string and passes it to ` \
              | xargs -t -n8 -P12           `# xargs (with -t to show what it's doing, can be removed) sends 8 arguments at a time across 12 threads to` \
                dig a +nocmd +noall +answer `# dig, which passes results to` \
              | awk '{print $1}'            `# awk, outputs word 1` \
              | sed -e 's/.$//'             `# sed, which trims off the trailing dot (google.com. -> google.com)` \
              | awk '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}{printf("\n")}')" # deduplicate
  # now do things with them 
  for validdomain in $domainlist; do
    echo "Valid: $validdomain"
  done
fi
```