### PR TITLE
feat: support orange and free bypass

### DIFF
--- a/contributors/yostyle.md
+++ b/contributors/yostyle.md
@@ -1,0 +1,9 @@
+2023-05-23
+
+I hereby agree to the terms of the "OpenMPTCProuter Individual Contributor License Agreement", with MD5 checksum bc827a07eb93611d793ddb7c75083c00.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Yoan Pintas https://github.com/yostyle

--- a/luci-app-omr-bypass/root/etc/uci-defaults/41_omr-bypass
+++ b/luci-app-omr-bypass/root/etc/uci-defaults/41_omr-bypass
@@ -118,6 +118,29 @@ if [ "$(uci -q get omr-bypass.amazonvideo)" = "" ]; then
 		commit omr-bypass
 	EOF
 fi
+if [ "$(uci -q get omr-bypass.free)" = "" ]; then
+	uci -q batch <<-EOF >/dev/null
+		set omr-bypass.free=proto
+		add_list omr-bypass.free.url='free.fr'
+		add_list omr-bypass.free.url='freebox.fr'
+		add_list omr-bypass.free.url='oqee.tv'
+		add_list omr-bypass.free.url='oqee.net'
+		commit omr-bypass
+	EOF
+fi
+if [ "$(uci -q get omr-bypass.orange)" = "" ]; then
+	uci -q batch <<-EOF >/dev/null
+		set omr-bypass.orange=proto
+		add_list omr-bypass.orange.url='orange.fr'
+		add_list omr-bypass.orange.url='sosh.fr'
+		add_list omr-bypass.orange.url='liveperson.net'
+		add_list omr-bypass.orange.url='liveperson.com'
+		add_list omr-bypass.orange.url='lpsn.net'
+		add_list omr-bypass.orange.url='lpsnmedia.net'
+		add_list omr-bypass.orange.url='francetelecom.fr'
+		commit omr-bypass
+	EOF
+fi
 #if [ "$(uci -q get omr-bypass.global)" = "" ]; then
 #	uci -q batch <<-EOF >/dev/null
 #		set omr-bypass.global=global


### PR DESCRIPTION
Support Orange and Free domains in OMR bypass. We have to use them if we want to use Orange tv (web and mobile app) and/or oqee (free tv) on Android TV.
