### PR TITLE
fix typo in cake autorate delay threshold

### DIFF
--- a/sqm-autorate/files/usr/share/sqm-autorate/config_template.sh
+++ b/sqm-autorate/files/usr/share/sqm-autorate/config_template.sh
@@ -79,7 +79,7 @@ reflector_ping_interval_s=$(uci -q get sqm.${INTERFACE}.reflector_ping_interval_
 # (adjustment significant at sub 12Mbit/s rates, else negligible)
 #logger -t "sqm-autorate" "ping for ${INTERFACE} (${ul_if}): $(echo $(/sbin/uci -q get sqm.${INTERFACE}.delay_thr_ms || echo '100'))"
 #dl_owd_delta_thr_ms=$(echo $(echo $(uci -q get sqm.${INTERFACE}.delay_thr_ms || echo $(echo "$(/usr/bin/ping -B -w 5 -c 5 -I ${ul_if} 1.1.1.1 | cut -d '/' -s -f6 | tr -d '\n' 2>/dev/null)+30" | bc) || echo "100")) + "0.1" | bc)  # (milliseconds)
-dl_owd_delta_thr_mss=$(uci -q get sqm.${INTERFACE}.delay_thr_ms || echo "250")
+dl_owd_delta_thr_ms=$(uci -q get sqm.${INTERFACE}.delay_thr_ms || echo "250")
 ul_owd_delta_thr_ms=${dl_owd_delta_thr_ms}
 
 # average owd delta threshold in ms at which maximum adjust_down_bufferbloat is applied


### PR DESCRIPTION
cake autorate fails to start because `dl_owd_delta_thr_mss` is an invalid config option