### PR TITLE
don't use ICMP echo for tsping

### DIFF
--- a/sqm-autorate/files/usr/share/sqm-autorate/config_template.sh
+++ b/sqm-autorate/files/usr/share/sqm-autorate/config_template.sh
@@ -134,7 +134,7 @@ log_file_export_compress=1 # compress log file exports using gzip and append .gz
 # the firewall mark.
 # WARNING: no error checking so use at own risk!
 #ping_extra_args="-B -I ${INTERFACE}"
-ping_extra_args="-i ${ul_if} -e"
+ping_extra_args="-i ${ul_if}"
 
 # a wrapper for ping binary - used as a prefix for the real command
 # e.g., when using mwan3, it is recommended to set it like this:


### PR DESCRIPTION
    switching tsping to icmp echo mode also changes the output columns, as
    well as the output data.

    echo mode:
    1710699541.701846,8.8.8.8,0,16
    timestamp,server,seq,rtt

    timestamp mode:
    1710699697.590335,8.8.8.8,0,66097563,66097546,66097546,66097590,27,44,-17

    This gets parsed by cake-autorate as follows:
    read -r timestamp reflector seq _ _ _ _ _ dl_owd_ms ul_owd_ms checksum <<< "${command[@]:1}"

    While tsping runs in echo mode, cake-autorate won't detect any ping
    responses and fall back to doing nothing.

I suppose this was changed because starlink seems filter out icmp timestamp responses? (I think I read that somewhere while trying to figure out why sqm-autorate wasn't working)
Sadly using echo mode doesn't really solve this problem as it breaks cake-autorate for all users.
