### PR TITLE
omr-quota does not work as expected due to a typo in checking json field "months"

### DIFF
--- a/contributors/bdaylik.md
+++ b/contributors/bdaylik.md
@@ -1,0 +1,9 @@
+2024-03-22
+
+I hereby agree to the terms of the "OpenMPTCProuter Individual Contributor License Agreement", with MD5 checksum bc827a07eb93611d793ddb7c75083c00.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Baris Daylik https://github.com/bdaylik

--- a/omr-quota/files/bin/omr-quota
+++ b/omr-quota/files/bin/omr-quota
@@ -11,8 +11,8 @@ shift
 # main loop
 while true; do
 	OMR_QUOTA_REAL_INTERFACE="$(ifstatus $OMR_QUOTA_INTERFACE | jsonfilter -e '@.l3_device')"
-	rx=`vnstat -i $OMR_QUOTA_REAL_INTERFACE --json | jsonfilter -q -e '@.interfaces[0].traffic.months[-1].rx' | tr -d "\n"`
-	tx=`vnstat -i $OMR_QUOTA_REAL_INTERFACE --json | jsonfilter -q -e '@.interfaces[0].traffic.months[-1].tx' | tr -d "\n"`
+	rx=`vnstat -i $OMR_QUOTA_REAL_INTERFACE --json | jsonfilter -q -e '@.interfaces[0].traffic.month[-1].rx' | tr -d "\n"`
+	tx=`vnstat -i $OMR_QUOTA_REAL_INTERFACE --json | jsonfilter -q -e '@.interfaces[0].traffic.month[-1].tx' | tr -d "\n"`
 	tt=$((rx + tx))
 	if [ -n "$OMR_QUOTA_RX" ] && [ "$OMR_QUOTA_RX" -gt 0 ] && [ -n "$rx" ] && [ "$OMR_QUOTA_RX" -le "$rx" ]; then
 		if [ "$(ifstatus $OMR_QUOTA_INTERFACE | jsonfilter -e '@.up')" = "true" ]; then


### PR DESCRIPTION
vnstat json does not contain a field named "months". The name of the field is "month". This prevents this script from managing quotas.