### PR TITLE
update vnstat_backup service to use default DatabaseDir if not specified

### DIFF
--- a/openmptcprouter/files/etc/init.d/vnstat_backup
+++ b/openmptcprouter/files/etc/init.d/vnstat_backup
@@ -10,12 +10,13 @@ START=98
 STOP=10
  
 vnstat_option() {
-    sed -ne "s/^[;]*$1[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" /etc/vnstat.conf
+    sed -ne "s/^[[:space:]]*$1[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" /etc/vnstat.conf
 }
  
 BACKUP_FILE=/etc/vnstat_backup.tar.gz
 LOGGER_TAG=vnstat_backup
 VNSTAT_DIR="$(vnstat_option DatabaseDir)"
+[ -n "$VNSTAT_DIR" ] || VNSTAT_DIR="/var/lib/vnstat"
 
 _chk_omrquota() {
 	config_get enabled $1 enabled


### PR DESCRIPTION
Instead of reading a commented out field I'd suggest using the default DatabaseDir value if none found in the config.