### PR TITLE
update omr-quota to compare in kbits as mentioned in GUI

### DIFF
--- a/omr-quota/files/bin/omr-quota
+++ b/omr-quota/files/bin/omr-quota
@@ -11,8 +11,10 @@ shift
 # main loop
 while true; do
 	OMR_QUOTA_REAL_INTERFACE="$(ifstatus $OMR_QUOTA_INTERFACE | jsonfilter -e '@.l3_device')"
-	rx=`vnstat -i $OMR_QUOTA_REAL_INTERFACE --json | jsonfilter -q -e '@.interfaces[0].traffic.month[-1].rx' | tr -d "\n"`
-	tx=`vnstat -i $OMR_QUOTA_REAL_INTERFACE --json | jsonfilter -q -e '@.interfaces[0].traffic.month[-1].tx' | tr -d "\n"`
+	rx_bits=`vnstat -i $OMR_QUOTA_REAL_INTERFACE --json | jsonfilter -q -e '@.interfaces[0].traffic.month[-1].rx' | tr -d "\n"`
+	tx_bits=`vnstat -i $OMR_QUOTA_REAL_INTERFACE --json | jsonfilter -q -e '@.interfaces[0].traffic.month[-1].tx' | tr -d "\n"`
+	rx=$((rx_bits/1024))
+	tx=$((tx_bits/1024))
 	tt=$((rx + tx))
 	if [ -n "$OMR_QUOTA_RX" ] && [ "$OMR_QUOTA_RX" -gt 0 ] && [ -n "$rx" ] && [ "$OMR_QUOTA_RX" -le "$rx" ]; then
 		if [ "$(ifstatus $OMR_QUOTA_INTERFACE | jsonfilter -e '@.up')" = "true" ]; then


### PR DESCRIPTION
vnstat by default reports the values in bits, however the OMR UI configuration asks values to be given in kbits. This commit fixes the omr-quota script by converting vnstat output to kbits.
