### PR TITLE
update omr-quota to up the interface when its usage is below threshold

### DIFF
--- a/omr-quota/files/bin/omr-quota
+++ b/omr-quota/files/bin/omr-quota
@@ -29,7 +29,7 @@ while true; do
 			logger -t "OMR-QUOTA" "Set interface $OMR_QUOTA_INTERFACE down, RX+TX quota reached"
 			ifdown $OMR_QUOTA_INTERFACE
 		fi
-	elif [ -n "$OMR_QUOTA_RX" ] && [ "$OMR_QUOTA_RX" -gt 0 ] && [ -n "$OMR_QUOTA_TX" ] && [ "$OMR_QUOTA_TX" -gt 0 ] && [ -n "$OMR_QUOTA_TT" ] && [ "$OMR_QUOTA_TT" -gt 0 ] && [ "$(ifstatus $OMR_QUOTA_INTERFACE | jsonfilter -e '@.up')" = "false" ]; then
+	elif [ "$(ifstatus $OMR_QUOTA_INTERFACE | jsonfilter -e '@.up')" = "false" ]; then
 		logger -t "OMR-QUOTA" "Set interface $OMR_QUOTA_INTERFACE up"
 		ifup $OMR_QUOTA_INTERFACE
 	fi


### PR DESCRIPTION
Existing condition for the upping the interface asks for all 3 checks to have positive values (RX, TX and TT). However this is not necessary as some can be set to 0 to disable the check.

This modification makes sure that if the above checks for RX, TX and TT values have failed, thus the usage is still below the set quota, the interface is set to be up.

Thanks to this modification its possible to set only one check positive (e.g. TT) and let the script automatically down and up the interface as expected.
