### PR TITLE
update vnstat_backup service to start before and end after the vnstat service

### DIFF
--- a/openmptcprouter/files/etc/init.d/vnstat_backup
+++ b/openmptcprouter/files/etc/init.d/vnstat_backup
@@ -6,8 +6,8 @@ EXTRA_HELP=<<EOF
         restore Restore vnstat database
 EOF
  
-START=98
-STOP=10
+START=50
+STOP=60
  
 vnstat_option() {
     sed -ne "s/^[[:space:]]*$1[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" /etc/vnstat.conf


### PR DESCRIPTION
Currently vnstat_backup service runs after vnstat runs and overwrites newly initialized database of vnstat causing it to crash and restart.

Moving vnstat_backup service before vnstat lets it create the database before vnstat runs. This allows an error free operation.

Similarly moving vnstat_backup termination after vnstat lets it backup a database after all of its file handles are closed making sure that the database won't be corrupt.