### PR TITLE
Update omr-tracker-ss

### DIFF
--- a/omr-tracker/files/bin/omr-tracker-ss
+++ b/omr-tracker/files/bin/omr-tracker-ss
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # vim: set noexpandtab tabstop=4 shiftwidth=4 softtabstop=4 :
 
 [ -n "$1" ] || exit


### PR DESCRIPTION
#!/bin/bash
It is a script with the header line #!/bin/bash. OpenWrt systems usually do not have /bin/bash (the default is busybox's /bin/sh)

Thanks for your contribution to OpenMPTCProuter!

You need to follow contributing rules.

Please remove this message before posting the pull request.
