### PR TITLE
Most modern 4g modems don't have reset implemented.

### DIFF
--- a/contributors/eugenydavydov.md
+++ b/contributors/eugenydavydov.md
@@ -1,0 +1,9 @@
+2026-03-31
+
+I hereby agree to the terms of the "OpenMPTCProuter Individual Contributor License Agreement", with MD5 checksum bc827a07eb93611d793ddb7c75083c00.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Eugeny Davydov https://github.com/eugenydavydov

--- a/omr-tracker/files/usr/share/omr/post-tracking.d/002-error
+++ b/omr-tracker/files/usr/share/omr/post-tracking.d/002-error
@@ -47,7 +47,7 @@ if [ "$OMR_TRACKER_STATUS" = "ERROR" ] || { [ "$OMR_TRACKER_INTERFACE" != "omrvp
 				mm_state_failed=$(modemmanager_get_field "${MODEM_STATUS}" "modem.generic.state-failed-reason")
 				if [ "$mm_state_failed" = "unknown-capabilities" ]; then
 					_log "Interface $OMR_TRACKER_INTERFACE in failed state in ModemManager, reset modem..."
-					/usr/bin/mmcli -m ${modem} -r >/dev/null 2>&1
+					/usr/bin/mmcli -m ${modem} -d >/dev/null 2>&1 && /usr/bin/mmcli -m ${modem} -e >/dev/null 2>&1
 					sleep $(uci -q get network.$OMR_TRACKER_INTERFACE.delay || echo '120')
 				elif false && [ "$mm_state_failed" = "sim-missing" ]; then
 					_log "Interface $OMR_TRACKER_INTERFACE in failed state in ModemManager, reset modem..."

--- a/omr-tracker/files/usr/share/omr/post-tracking.d/002-error
+++ b/omr-tracker/files/usr/share/omr/post-tracking.d/002-error
@@ -51,7 +51,7 @@ if [ "$OMR_TRACKER_STATUS" = "ERROR" ] || { [ "$OMR_TRACKER_INTERFACE" != "omrvp
 					sleep $(uci -q get network.$OMR_TRACKER_INTERFACE.delay || echo '120')
 				elif false && [ "$mm_state_failed" = "sim-missing" ]; then
 					_log "Interface $OMR_TRACKER_INTERFACE in failed state in ModemManager, reset modem..."
-					/usr/bin/mmcli -m ${modem} -r >/dev/null 2>&1
+					/usr/bin/mmcli -m ${modem} --command="AT+CFUN=1,1" >/dev/null 2>&1
 					#_log "Interface $OMR_TRACKER_INTERFACE in failed state sim-missing in ModemManager, reset modem..."
 					#mm_primary_port=$(modemmanager_get_field "${MODEM_STATUS}" "modem.generic.primary-port")
 					#mbimcli -p -d /dev/$mm_primary_port --ms-device-reset >/dev/null 2>&1


### PR DESCRIPTION
Most modern 4g modems (for example: Fibocom l850, l860, Foxconn T77W968) don't have reset implemented:

~# /usr/bin/mmcli -m 0 -r
error: couldn't reset the modem: 'GDBus.Error:org.freedesktop.ModemManager1.Error.Core.Unsupported: Unsupported: Operation not supported'

So, replacing this to "modem disable+modem enable" reset modem successfully.